### PR TITLE
fix: remove pcall for the wrapped function

### DIFF
--- a/src/memoize.lua
+++ b/src/memoize.lua
@@ -92,12 +92,9 @@ function Memoizer.new(seed, capacity, byte_capacity)
 			end
 
 			-- miss
-			local ok, res = pcall(function(...)
+			local res = (function(...)
 				return _pack(fn(...))
-			end, ...)
-			if not ok then
-				error(res)
-			end
+			end)(...)
 
 			local storedEntry = { result = res }
 			if ttl and type(ttl) == "number" then


### PR DESCRIPTION
The pcall checks inside the wrapper function were responsible for the early stack overflow. Removed for now.
Fixes: #1 